### PR TITLE
fix:Compatible browser Chinese environment

### DIFF
--- a/extensions/noi-ask/main.js
+++ b/extensions/noi-ask/main.js
@@ -116,7 +116,9 @@ class GeminiAsk extends NoiAsk {
   }
 
   static submit() {
-    const btn = document.querySelector('button[aria-label*="Send message"]');
+    const userLang = navigator.language || navigator.userLanguage;
+    const ariaLabel = userLang.indexOf('zh') !== -1 ? '发送消息' : 'Send message';
+    const btn = document.querySelector(`button[aria-label*="${ariaLabel}"]`);
     if (btn) {
       btn.setAttribute('aria-disabled', 'false'); // doesn't work alone
       btn.focus();


### PR DESCRIPTION
浏览器中文环境下，Gemini页面中aria-label属性内容为中文：“发送消息”，需要做兼容