### PR TITLE
noi-ask: Fix paid version chatGPT submit button selector

### DIFF
--- a/extensions/noi-ask/main.js
+++ b/extensions/noi-ask/main.js
@@ -48,7 +48,13 @@ class OpenAIAsk extends NoiAsk {
   static url = 'https://chatgpt.com';
 
   static submit() {
-    const btn = document.querySelector('button[data-testid="send-button"]');
+    let btn = document.querySelector('button[data-testid="send-button"]');
+    if (!btn) {
+      // ChatGPT paid version is running on a different UI, it does not have `data-testid`.
+      // Luckily svg is unique on the whole page
+      const svg = document.querySelectorAll('svg[class*="icon-2xl"]')[0];
+      btn = svg.parentElement;
+    }
     if (btn) this.autoClick(btn);
   }
 }


### PR DESCRIPTION
In chatGPT paid version, the submit button selector is different. 
![Paid version ChatGPT html tree](https://github.com/lencx/Noi/assets/5086389/07b6f7f6-1d3b-4746-8a3d-b79c2944cc05)

This PR added the solution for it. 
It has passed test locally against the latest Noi v0.4.0
