### PR TITLE
Noi-ask Extensions: Update ChatGPT submit btn selector

### DIFF
--- a/extensions/noi-ask/main.js
+++ b/extensions/noi-ask/main.js
@@ -48,7 +48,10 @@ class OpenAIAsk extends NoiAsk {
   static url = 'https://chatgpt.com';
 
   static submit() {
-    const btn = document.querySelector('button[data-testid="send-button"]');
+    const forms = document.querySelectorAll('main form');
+    const form = forms[forms.length - 1];
+    const buttons = form.querySelectorAll('button');
+    const btn = buttons[buttons.length - 1];
     if (btn) this.autoClick(btn);
   }
 }


### PR DESCRIPTION
`data-testid` does not exist on paid version. This fix works on both paid and unpaid version of ChatGPT. 
It relies on the Dom structure:
"main > last form > last button" should be the submit button

Test passed on the local using Noi v0.4.0
