### PR TITLE
feat(config): add Grokipedia to AI services

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,4 @@ build/
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+website/package-lock.json

--- a/configs/noi_awesome.json
+++ b/configs/noi_awesome.json
@@ -96,6 +96,15 @@
     "favicon": "https://grok.com/images/favicon-dark.png"
   },
   {
+    "id": "noi:grokipedia",
+    "parent": "noi@ai",
+    "text": "Grokipedia",
+    "url": "https://grokipedia.com",
+    "active": false,
+    "ask": true,
+    "favicon": "https://grokipedia.com/favicon.ico"
+  },
+  {
     "id": "noi:githubcopilot",
     "parent": "noi@ai",
     "text": "GitHub Copilot",


### PR DESCRIPTION
Add Grokipedia (grokipedia.com) as a new AI assistant option in the noi_awesome configuration. #434

This PR adds [Grokipedia](https://grokipedia.com) as a new AI assistant shortcut in the Noi configuration.

### Changes
- Added `noi:grokipedia` entry to [configs/noi_awesome.json](https://github.com/lencx/Noi/compare/main...sony-level:Noi:add-grokipedia-shortcut?expand=1#diff-99cbc0e6d0f9ebcff81e1eaecc79714dcedeb7ea1c011cc4507aa79cffd65b73) under the AI category
- Configured with `ask: true` to enable prompt functionality

### Testing
- Verified the JSON structure is valid
- Grokipedia service loads correctly in the sidebar